### PR TITLE
Option to recreate file list before restart; Stop slideshow on suspend and restart on resume

### DIFF
--- a/MMM-ImageSlideshow.js
+++ b/MMM-ImageSlideshow.js
@@ -34,6 +34,8 @@ Module.register("MMM-ImageSlideshow", {
         validImageFileExtensions: 'bmp,jpg,gif,png',
 		// a delay timer after all images have been shown, to wait to restart (in ms)
 		delayUntilRestart: 0,
+		// update the file list each time all images had been displayed
+		updateFileBeforeRestart: false,
 	},
     // load function
 	start: function () {
@@ -83,7 +85,10 @@ Module.register("MMM-ImageSlideshow", {
 					this.interval = setInterval(function() {
 						self.updateDom();
 						}, this.config.slideshowSpeed);					
-                }
+                } else {
+					this.loaded = false;
+					this.updateDom();
+				}
 			}
 		}
     },    
@@ -113,6 +118,9 @@ Module.register("MMM-ImageSlideshow", {
 				var showSomething = true;
                 // if exceeded the size of the list, go back to zero
                 if (this.imageIndex == this.imageList.length) {
+					if (this.config.updateFileBeforeRestart){
+						this.sendSocketNotification('IMAGESLIDESHOW_UPDATE_FILE_LIST', this.config);
+					}
 					// if delay after last image, set to wait
 					if (this.config.delayUntilRestart > 0) {
 						this.imageIndex = -2;
@@ -122,11 +130,12 @@ Module.register("MMM-ImageSlideshow", {
 						var self = this;
 						this.interval = setInterval(function() {
 							self.updateDom(0);
-							}, this.config.delayUntilRestart);									
+							}, this.config.delayUntilRestart);
 					}
 					// if not reset index
-					else
+					else {
 						this.imageIndex = 0;
+					}
 				}
 				if (showSomething) {
 					// create the image dom bit

--- a/MMM-ImageSlideshow.js
+++ b/MMM-ImageSlideshow.js
@@ -61,6 +61,17 @@ Module.register("MMM-ImageSlideshow", {
 			this.interval = null;
         }
 	},
+	suspend: function() {
+		const self = this
+		clearInterval(self.interval);
+	  },
+	
+	resume: function() {
+		const self = this
+		this.interval = setInterval(function() {
+			self.updateDom(0);
+			}, this.config.slideshowSpeed);
+	},
 	// Define required scripts.
 	getStyles: function() {
         // the css contains the make grayscale code
@@ -111,7 +122,7 @@ Module.register("MMM-ImageSlideshow", {
 					this.interval = setInterval(function() {
 						self.updateDom(0);
 						}, this.config.slideshowSpeed);						
-				}				
+				}		
                 // iterate the image list index
                 this.imageIndex += 1;
 				// set flag to show stuff

--- a/MMM-ImageSlideshow.js
+++ b/MMM-ImageSlideshow.js
@@ -35,7 +35,7 @@ Module.register("MMM-ImageSlideshow", {
 		// a delay timer after all images have been shown, to wait to restart (in ms)
 		delayUntilRestart: 0,
 		// update the file list each time all images had been displayed
-		updateFileBeforeRestart: false,
+		updateFileListBeforeRestart: false,
 	},
     // load function
 	start: function () {
@@ -118,7 +118,7 @@ Module.register("MMM-ImageSlideshow", {
 				var showSomething = true;
                 // if exceeded the size of the list, go back to zero
                 if (this.imageIndex == this.imageList.length) {
-					if (this.config.updateFileBeforeRestart){
+					if (this.config.updateFileListBeforeRestart){
 						this.sendSocketNotification('IMAGESLIDESHOW_UPDATE_FILE_LIST', this.config);
 					}
 					// if delay after last image, set to wait

--- a/MMM-ImageSlideshow.js
+++ b/MMM-ImageSlideshow.js
@@ -70,7 +70,8 @@ Module.register("MMM-ImageSlideshow", {
 		const self = this
 		this.interval = setInterval(function() {
 			self.updateDom(0);
-			}, this.config.slideshowSpeed);
+		}, this.config.slideshowSpeed);
+		self.updateDom(0)
 	},
 	// Define required scripts.
 	getStyles: function() {

--- a/README.md
+++ b/README.md
@@ -62,7 +62,15 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>0</code>
 				<br>This value is <b>OPTIONAL</b>
 			</td>
-		</tr>		
+		</tr>
+		<tr>
+			<td><code>updateFileListBeforeRestart</code></td>
+			<td>Boolean value, Should the file list be recreated before the slideshow restarts?<br>
+				<br><b>Example:</b> <code>true</code>
+				<br><b>Default value:</b> <code>false</code>
+				<br>This value is <b>OPTIONAL</b>
+			</td>
+		</tr>
 		<tr>
 			<td><code>fixedImageWidth</code></td>
 			<td>Integer value, sets a fixed pixel width for all the images to be shown. If set to 0, the image's actual width is used.<br>
@@ -110,6 +118,6 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>'bmp,jpg,gif,png'</code>
 				<br>This value is <b>OPTIONAL</b>
 			</td>
-		</tr>         
+		</tr>
     </tbody>
 </table>

--- a/node_helper.js
+++ b/node_helper.js
@@ -20,7 +20,7 @@ var FileSystemImageSlideshow = require("fs");
 module.exports = NodeHelper.create({
     // subclass start method, clears the initial config array
     start: function() {
-        this.moduleConfigs = [];
+        this.started = false;
     },
     // shuffles an array at random and returns it
     shuffleArray: function(array) {
@@ -105,12 +105,17 @@ module.exports = NodeHelper.create({
     },
     // subclass socketNotificationReceived, received notification from module
     socketNotificationReceived: function(notification, payload) {
+        // this to self
+        var self = this;
         if (notification === "IMAGESLIDESHOW_REGISTER_CONFIG") {
-            // add the current config to an array of all configs used by the helper
-            this.moduleConfigs.push(payload);
-            // this to self
-            var self = this;
             // get the image list
+            var imageList = this.gatherImageList(payload);
+            // build the return payload
+            var returnPayload = { identifier: payload.identifier, imageList: imageList };
+            // send the image list back
+            self.sendSocketNotification('IMAGESLIDESHOW_FILELIST', returnPayload );
+            self.started = true
+        } else if ((notification === "IMAGESLIDESHOW_UPDATE_FILE_LIST") && self.started){
             var imageList = this.gatherImageList(payload);
             // build the return payload
             var returnPayload = { identifier: payload.identifier, imageList: imageList };


### PR DESCRIPTION
Hi,

i am using your module in a Photo-Frame which uses a profile module to implement pages.
Two features were missing to fulfill my requirements to 100%:
* The file list should be recreated before the slideshow starts again. Both to get a new random order and to integrate new files in the folder
* The slideshow should stop if an different page is displayed (module gets hidden) and restart on the last position if the module gets visible again

I implemented both features and if you like it would be great if you merge them to the original version.